### PR TITLE
修复改变书签顺序后不能保存的问题

### DIFF
--- a/src/vuex/modules/bookmark.js
+++ b/src/vuex/modules/bookmark.js
@@ -68,6 +68,7 @@ export const actions = {
 export const mutations = {
     [types.RECEIVE_BOOKMARKS](state, data) {
         state.bookmarks = data;
+        storage.setItem('GITHUBER_BOOKMARKS', state.bookmarks);
     },
     [types.RESTORE_BACKUP_BOOKMARKS](state, data) {
         data.map(item => {


### PR DESCRIPTION
之前是缺少了保存在storage中的步骤，改好以后本地试了试没什么问题。