### PR TITLE
:sparkles: 链接打开方式支持鼠标修饰键

### DIFF
--- a/src/views/components/bookmark.vue
+++ b/src/views/components/bookmark.vue
@@ -13,7 +13,9 @@
                 :key="inx"
                 :class="{edit: edit}"
                 @contextmenu="toggleEditAction"
-                @click="onLinkTapAction(item)"
+                @click.exact="onLinkTapAction(item)"
+                @click.meta="onLinkTapAction(item, true)"
+                @click.ctrl="onLinkTapAction(item, true)"
                 @dblclick="onEditAction(item, inx)"
             )
                 .el-icon-close(@click.stop="onRemoveAction(item)")
@@ -80,9 +82,9 @@ export default {
             await this.fetchBookmarks();
             this.$refs.scrollView.refresh();
         },
-        onLinkTapAction(item) {
+        onLinkTapAction(item, jump) {
             if (!this.edit) {
-                this.$emit('tap', item.url);
+                this.$emit('tap', item.url, jump);
             }
         },
         toggleEditAction(e) {

--- a/src/views/components/github-trending.vue
+++ b/src/views/components/github-trending.vue
@@ -44,7 +44,9 @@
             )
                 el-card.repositories(
                     v-if="query.type === 'repositories'"
-                    @click.native="onLinkTapAction(item.repo_link)"
+                    @click.native.exact="onLinkTapAction(item.repo_link)"
+                    @click.native.meta="onLinkTapAction(item.repo_link, true)"
+                    @click.native.ctrl="onLinkTapAction(item.repo_link, true)"
                 )
                     .repositories__title {{item.repo}}
                     .repositories__desc {{item.desc}}
@@ -61,7 +63,11 @@
                         img(v-for="(avatar, inx) in item.avatars" :key="inx" :src="avatar")
 
                 el-card.developers(v-if="query.type === 'developers'")
-                    .developers__author(@click="onLinkTapAction(item.link)")
+                    .developers__author(
+                        @click.exact="onLinkTapAction(item.link)"
+                        @click.meta="onLinkTapAction(item.link, true)"
+                        @click.ctrl="onLinkTapAction(item.link, true)"
+                    )
                         img.avatar(:src="item.avatar")
                         .author
                             h2 {{item.author}}
@@ -143,8 +149,8 @@ export default {
             loadingInstance.close();
             this.$refs.scrollView.refresh();
         },
-        onLinkTapAction(link) {
-            this.$emit('tap', link);
+        onLinkTapAction(link, jump) {
+            this.$emit('tap', link, jump);
         },
     },
     watch: {

--- a/src/views/components/search.vue
+++ b/src/views/components/search.vue
@@ -1,6 +1,6 @@
 <template lang="pug">
     .search
-        el-form(@submit.prevent.native="onSearchAction")
+        el-form(@submit.prevent.native="")
             el-tabs(v-model="activeEngineNavName" @tab-click="onSearchNameTapAction")
                 el-tab-pane(
                     v-for="item in searchEngine.engines"
@@ -15,6 +15,8 @@
                 :trigger-on-focus="false"
                 v-model="searchText"
                 @select="onSearchAction"
+                @keyup.enter.native.exact="onSearchAction"
+                @keyup.enter.native.shift="onSearchAction($event, true)"
             )
                 el-dropdown(
                     slot="prefix"
@@ -84,17 +86,18 @@ export default {
 
             if (str) {
                 try {
-                    await this.fetchSuperpage(str);
+                    // 百度取消了网站联想的功能
+                    // await this.fetchSuperpage(str);
                     await this.fetchSuggestion(str);
 
                     this.suggestions.map(name => result.push({ name }));
 
-                    if (this.superpages.length) {
-                        result.unshift({
-                            ...this.superpages[0],
-                            value: str
-                        });
-                    }
+                    // if (this.superpages.length) {
+                    //     result.unshift({
+                    //         ...this.superpages[0],
+                    //         value: str
+                    //     });
+                    // }
                 } catch (e) {
                     console.log(e);
                 }
@@ -118,7 +121,7 @@ export default {
          * @param {String} item.value 默认搜索值
          * @param {String} item.name 搜索联想内容
          */
-        onSearchAction({ search, name, url, value }) {
+        onSearchAction({ search, name, url, value }, jump = false) {
             if (value) {
                 this.searchText = value;
             }
@@ -139,7 +142,7 @@ export default {
                 this.searchText = name;
             }
 
-            return this.$emit('search', `${this.searchEngineNav.url}${this.searchText}`);
+            return this.$emit('search', `${this.searchEngineNav.url}${this.searchText}`, jump);
         },
 
         /**
@@ -162,6 +165,10 @@ export default {
         onSearchNameTapAction({ name }) {
             this.activeEngineNavName = name;
         },
+
+        onSubmit(e) {
+            console.log(e);
+        }
     },
     watch: {
         activeEngineName(val) {

--- a/src/views/main.vue
+++ b/src/views/main.vue
@@ -74,8 +74,8 @@ export default {
         ...mapActions('bookmark', ['removeBookmark', 'restoreBackupBookmarks', 'saveBookmark']),
 
         // 搜索事件
-        onSearchAction(url) {
-            if (this.config.openSearchInNewTab) {
+        onSearchAction(url, jump = false) {
+            if (this.config.openSearchInNewTab || jump) {
                 chrome.tabs.create({ url });
             } else {
                 chrome.tabs.update({ url });
@@ -83,8 +83,8 @@ export default {
         },
 
         // 点击链接跳转
-        onLinkTapAction(url) {
-            if (this.config.openLinkInNewTab) {
+        onLinkTapAction(url, jump = false) {
+            if (this.config.openLinkInNewTab || jump) {
                 chrome.tabs.create({ url });
             } else {
                 chrome.tabs.update({ url });
@@ -92,8 +92,8 @@ export default {
         },
 
         // 点击书签跳转
-        onBookmarkTapAction(url) {
-            if (this.config.openBookmarkInNewTab) {
+        onBookmarkTapAction(url, jump = false) {
+            if (this.config.openBookmarkInNewTab || jump) {
                 chrome.tabs.create({ url });
             } else {
                 chrome.tabs.update({ url });

--- a/src/vuex/modules/search.js
+++ b/src/vuex/modules/search.js
@@ -45,6 +45,7 @@ export const actions = {
             try {
                 const text = decodeURIComponent(item);
                 const array = text.split('0{#S+_}');
+                console.log(text, array);
                 const content = JSON.parse(array[1]);
 
                 obj.name = content[4];

--- a/static/manifest.json
+++ b/static/manifest.json
@@ -16,6 +16,7 @@
         },
         "default_popup": "./popup.html"
     },
+    "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'",
     "chrome_url_overrides": {
         "newtab": "./index.html"
     },


### PR DESCRIPTION
通过下面操作，可以快速新标签页打开链接：

- [x] Mac 下点击「Cmd + 鼠标左键」
- [x] Windows 下点击「Ctrl + 鼠标左键」
- [x] 搜索框键入「Shift + Enter」
